### PR TITLE
Upload attachment file at not utf8 env

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,11 @@ uploadArchives {
             }
 
             repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', hasProperty('ossrhPassword')?ossrhPassword:'')
             }
 
             snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
+                authentication(userName: hasProperty('ossrhUsername')?ossrhUsername:'', hasProperty('ossrhPassword')?ossrhPassword:'')
             }
 
             pom.project {

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 sourceCompatibility=1.6
+tasks.withType(JavaCompile){ options.encoding = 'UTF-8' }
 
 group = 'com.nulab-inc'
 archivesBaseName = 'backlog4j'

--- a/src/main/java/com/nulabinc/backlog4j/http/BacklogHttpClientImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/http/BacklogHttpClientImpl.java
@@ -189,7 +189,7 @@ public class BacklogHttpClientImpl implements BacklogHttpClient {
 
         try {
             OutputStream out = new BufferedOutputStream(urlConnection.getOutputStream());
-            PrintWriter writer = new PrintWriter(out);
+            PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(out, "UTF-8")));
             for (Map.Entry<String, Object> entry : params.entrySet()) {
                 String name = entry.getKey();
                 Object value = entry.getValue();


### PR DESCRIPTION
I'm using ubuntu 14.04 on docker. (Java's default encoding is ANSI_X3.4-1968)

This environment occured two problem.

1. I can't be builded.
1. I can't upload attachment file whose name doesn't garbled.
  - ex) I upload file whose name is "テストtest.txt"
<img width="319" alt="2016-05-24 14 15 22" src="https://cloud.githubusercontent.com/assets/3388548/15493081/705f4782-21bc-11e6-91cb-a8e0895d0292.png">
