### PR TITLE
Empty-value support for update issue.

### DIFF
--- a/src/main/java/com/nulabinc/backlog4j/api/option/UpdateIssueParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/UpdateIssueParams.java
@@ -15,6 +15,8 @@ import java.util.Set;
  */
 public class UpdateIssueParams extends PatchParams {
 
+    public final long PARENT_ISSUE_NOT_SET = -1;
+
     private Object issueIdOrKey;
 
     public UpdateIssueParams(Object issueIdOrKey) {
@@ -31,7 +33,11 @@ public class UpdateIssueParams extends PatchParams {
     }
 
     public UpdateIssueParams parentIssueId(long parentIssueId) {
-        parameters.add(new NameValuePair("parentIssueId", String.valueOf(parentIssueId)));
+        if (parentIssueId == PARENT_ISSUE_NOT_SET) {
+            parameters.add(new NameValuePair("parentIssueId", ""));
+        } else {
+            parameters.add(new NameValuePair("parentIssueId", String.valueOf(parentIssueId)));
+        }
         return this;
     }
 

--- a/src/main/java/com/nulabinc/backlog4j/api/option/UpdateIssueParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/UpdateIssueParams.java
@@ -15,7 +15,7 @@ import java.util.Set;
  */
 public class UpdateIssueParams extends PatchParams {
 
-    public final long PARENT_ISSUE_NOT_SET = -1;
+    public static final long PARENT_ISSUE_NOT_SET = -1;
 
     private Object issueIdOrKey;
 


### PR DESCRIPTION
課題情報の更新APIでparent issue idを未設定にする方法がなかったので修正しました。

https://developer.nulab-inc.com/ja/docs/backlog/api/2/update-issue