### PR TITLE
Add safe wrapper for id or key value.

### DIFF
--- a/src/main/java/com/nulabinc/backlog4j/api/option/AddCategoryParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/AddCategoryParams.java
@@ -1,6 +1,5 @@
 package com.nulabinc.backlog4j.api.option;
 
-import com.nulabinc.backlog4j.BacklogAPIException;
 import com.nulabinc.backlog4j.http.NameValuePair;
 
 /**

--- a/src/main/java/com/nulabinc/backlog4j/core/IdOrKey.java
+++ b/src/main/java/com/nulabinc/backlog4j/core/IdOrKey.java
@@ -32,7 +32,7 @@ public class IdOrKey {
         return new IdOrKey(Union.<Long, String>left(id));
     }
 
-    public static IdOrKey id(int id) {
-        return new IdOrKey(Union.<Long, String>left((long)id));
+    public static IdOrKey id(Integer id) {
+        return new IdOrKey(Union.<Long, String>left(id.longValue()));
     }
 }

--- a/src/main/java/com/nulabinc/backlog4j/core/IdOrKey.java
+++ b/src/main/java/com/nulabinc/backlog4j/core/IdOrKey.java
@@ -2,6 +2,9 @@ package com.nulabinc.backlog4j.core;
 
 import java.util.Optional;
 
+/**
+ * @author nulab-inc
+ */
 public class IdOrKey {
     private Union<Long, String> idOrKey;
 

--- a/src/main/java/com/nulabinc/backlog4j/core/IdOrKey.java
+++ b/src/main/java/com/nulabinc/backlog4j/core/IdOrKey.java
@@ -1,0 +1,35 @@
+package com.nulabinc.backlog4j.core;
+
+import java.util.Optional;
+
+public class IdOrKey {
+    private Union<Long, String> idOrKey;
+
+    private IdOrKey(Union<Long, String> idOrKey) {
+        this.idOrKey = idOrKey;
+    }
+
+    public String toString() {
+        return this.idOrKey.toString();
+    }
+
+    public Optional<Long> id() {
+        return idOrKey.left();
+    }
+
+    public Optional<String> key() {
+        return idOrKey.right();
+    }
+
+    public static IdOrKey key(String key) {
+        return new IdOrKey(Union.<Long, String>right(key));
+    }
+
+    public static IdOrKey id(Long id) {
+        return new IdOrKey(Union.<Long, String>left(id));
+    }
+
+    public static IdOrKey id(int id) {
+        return new IdOrKey(Union.<Long, String>left((long)id));
+    }
+}

--- a/src/main/java/com/nulabinc/backlog4j/core/Union.java
+++ b/src/main/java/com/nulabinc/backlog4j/core/Union.java
@@ -34,14 +34,16 @@ public class Union<T1, T2> {
     public static <T, U> Union<T, U> left(T t1) throws InvalidParameterException {
         if (t1 == null) {
             throw new InvalidParameterException("value can't be null");
+        } else {
+            return new Union<T, U>(t1, null);
         }
-        return new Union<T, U>(t1, null);
     }
 
     public static <T, U> Union<T, U> right(U t2) throws InvalidParameterException {
         if (t2 == null) {
             throw new InvalidParameterException("value can't be null");
+        } else {
+            return new Union<T, U>(null, t2);
         }
-        return new Union<T, U>(null, t2);
     }
 }

--- a/src/main/java/com/nulabinc/backlog4j/core/Union.java
+++ b/src/main/java/com/nulabinc/backlog4j/core/Union.java
@@ -1,0 +1,44 @@
+package com.nulabinc.backlog4j.core;
+
+import java.security.InvalidParameterException;
+import java.util.Optional;
+
+public class Union<T1, T2> {
+    private T1 t1;
+    private T2 t2;
+
+    private Union(T1 t1, T2 t2) {
+        this.t1 = t1;
+        this.t2 = t2;
+    }
+
+    public String toString() {
+        if (this.t1 != null) {
+            return this.t1.toString();
+        } else {
+            return this.t2.toString();
+        }
+    }
+
+    public Optional<T1> left() {
+        return Optional.ofNullable(this.t1);
+    }
+
+    public Optional<T2> right() {
+        return Optional.ofNullable(this.t2);
+    }
+
+    public static <T, U> Union<T, U> left(T t1) throws InvalidParameterException {
+        if (t1 == null) {
+            throw new InvalidParameterException("value can't be null");
+        }
+        return new Union<T, U>(t1, null);
+    }
+
+    public static <T, U> Union<T, U> right(U t2) throws InvalidParameterException {
+        if (t2 == null) {
+            throw new InvalidParameterException("value can't be null");
+        }
+        return new Union<T, U>(null, t2);
+    }
+}

--- a/src/main/java/com/nulabinc/backlog4j/core/Union.java
+++ b/src/main/java/com/nulabinc/backlog4j/core/Union.java
@@ -3,6 +3,9 @@ package com.nulabinc.backlog4j.core;
 import java.security.InvalidParameterException;
 import java.util.Optional;
 
+/**
+ * @author nulab-inc
+ */
 public class Union<T1, T2> {
     private T1 t1;
     private T2 t2;

--- a/src/main/java/com/nulabinc/backlog4j/core/package-info.java
+++ b/src/main/java/com/nulabinc/backlog4j/core/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides the safe wrapper for using backlog4j
+ */
+package com.nulabinc.backlog4j.core;

--- a/src/test/java/com/nulabinc/backlog4j/core/IdOrKeyTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/core/IdOrKeyTest.java
@@ -1,0 +1,22 @@
+package com.nulabinc.backlog4j.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IdOrKeyTest {
+
+    @Test
+    public void useKey() {
+        IdOrKey keyVal = IdOrKey.key("test");
+
+        assertEquals("test", keyVal.toString());
+    }
+
+    @Test
+    public void useId() {
+        IdOrKey idVal = IdOrKey.id(5);
+
+        assertEquals("5", idVal.toString());
+    }
+}

--- a/src/test/java/com/nulabinc/backlog4j/core/IdOrKeyTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/core/IdOrKeyTest.java
@@ -4,6 +4,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * @author nulab-inc
+ */
 public class IdOrKeyTest {
 
     @Test

--- a/src/test/java/com/nulabinc/backlog4j/core/UnionTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/core/UnionTest.java
@@ -1,0 +1,35 @@
+package com.nulabinc.backlog4j.core;
+
+import org.junit.Test;
+
+import java.security.InvalidParameterException;
+
+import static org.junit.Assert.assertEquals;
+
+public class UnionTest {
+
+    @Test
+    public void useLeft() {
+        Union<String, Integer> strOrInt = Union.left("test");
+
+        assertEquals("test", strOrInt.toString());
+    }
+
+    @Test
+    public void recursiveUnion() {
+        Union<String, Union<String, Long>> nestedUnion =
+                Union.right(Union.<String, Long>right((long)5));
+
+        assertEquals("5", nestedUnion.toString());
+    }
+
+    @Test(expected = InvalidParameterException.class)
+    public void leftShouldThrowInvalidParameterException() {
+        Union<String, Long> invalid = Union.left(null);
+    }
+
+    @Test(expected = InvalidParameterException.class)
+    public void rightShouldThrowInvalidParameterException() {
+        Union<String, Long> invalid = Union.right(null);
+    }
+}

--- a/src/test/java/com/nulabinc/backlog4j/core/UnionTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/core/UnionTest.java
@@ -6,6 +6,9 @@ import java.security.InvalidParameterException;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * @author nulab-inc
+ */
 public class UnionTest {
 
     @Test


### PR DESCRIPTION
I added a safe wrapper for id or key parameter we have inside of the library. The wrapper can be used to add compile time safety when using backlog4j api. Implementing inside of the api take a long time. Object for id or key are used in many place not only parameters. Making changes at this level can be difficult without breaking backward compatibility. Maybe we can evaluate changing the type of parameter and data itself in major version where breaking changes are allowed. For now this solution will be enough i think.