### PR TITLE
Add an API for migration tool

### DIFF
--- a/src/main/java/com/nulabinc/backlog4j/BacklogClientBase.java
+++ b/src/main/java/com/nulabinc/backlog4j/BacklogClientBase.java
@@ -129,15 +129,22 @@ public abstract class BacklogClientBase{
     }
 
     protected BacklogHttpResponse delete(String endpoint) throws BacklogException {
-        return this.delete(endpoint, null);
-
+        return this.delete(endpoint, new ArrayList<NameValuePair>());
     }
 
     protected BacklogHttpResponse delete(String endpoint, NameValuePair param) throws BacklogException {
-        BacklogHttpResponse ires = httpClient.delete(endpoint, param);
+        List<NameValuePair> params = new ArrayList<NameValuePair>();
+        if (param != null) {
+            params.add(param);
+        }
+        return this.delete(endpoint, params);
+    }
+
+    protected BacklogHttpResponse delete(String endpoint, List<NameValuePair> parameters) throws BacklogException {
+        BacklogHttpResponse ires = httpClient.delete(endpoint, parameters);
         if (needTokenRefresh(ires)) {
             refreshToken();
-            ires = httpClient.delete(endpoint, param);
+            ires = httpClient.delete(endpoint, parameters);
         }
         checkError(ires);
         return ires;

--- a/src/main/java/com/nulabinc/backlog4j/BacklogClientBase.java
+++ b/src/main/java/com/nulabinc/backlog4j/BacklogClientBase.java
@@ -1,9 +1,6 @@
 package com.nulabinc.backlog4j;
 
-import com.nulabinc.backlog4j.api.option.GetParams;
-import com.nulabinc.backlog4j.api.option.PatchParams;
-import com.nulabinc.backlog4j.api.option.PostParams;
-import com.nulabinc.backlog4j.api.option.QueryParams;
+import com.nulabinc.backlog4j.api.option.*;
 import com.nulabinc.backlog4j.auth.AccessToken;
 import com.nulabinc.backlog4j.auth.OAuthSupport;
 import com.nulabinc.backlog4j.conf.BacklogConfigure;
@@ -85,7 +82,6 @@ public abstract class BacklogClientBase{
         return ires;
     }
 
-
     protected BacklogHttpResponse post(String endpoint) throws BacklogException {
         return this.post(endpoint, new ArrayList<NameValuePair>());
     }
@@ -130,6 +126,10 @@ public abstract class BacklogClientBase{
 
     protected BacklogHttpResponse delete(String endpoint) throws BacklogException {
         return this.delete(endpoint, new ArrayList<NameValuePair>());
+    }
+
+    protected BacklogHttpResponse delete(String endpoint, DeleteParams deleteParams) throws BacklogException {
+        return this.patch(endpoint, deleteParams.getParamList());
     }
 
     protected BacklogHttpResponse delete(String endpoint, NameValuePair param) throws BacklogException {

--- a/src/main/java/com/nulabinc/backlog4j/BacklogClientBase.java
+++ b/src/main/java/com/nulabinc/backlog4j/BacklogClientBase.java
@@ -129,7 +129,7 @@ public abstract class BacklogClientBase{
     }
 
     protected BacklogHttpResponse delete(String endpoint, DeleteParams deleteParams) throws BacklogException {
-        return this.patch(endpoint, deleteParams.getParamList());
+        return this.delete(endpoint, deleteParams.getParamList());
     }
 
     protected BacklogHttpResponse delete(String endpoint, NameValuePair param) throws BacklogException {

--- a/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
@@ -417,7 +417,7 @@ public class BacklogClientImpl extends BacklogClientBase implements BacklogClien
         return factory.createIssue(post(buildEndpoint("issues"), params));
     }
 
-    @Override
+    @Override @Deprecated
     public Issue importIssue(ImportIssueParams params) throws BacklogException {
         return factory.importIssue(post(buildEndpoint("issues/import"), params));
     }
@@ -427,12 +427,12 @@ public class BacklogClientImpl extends BacklogClientBase implements BacklogClien
         return factory.createIssue(patch(buildEndpoint("issues/" + params.getIssueIdOrKeyString()), params));
     }
 
-    @Override
+    @Override @Deprecated
     public Issue importUpdateIssue(ImportUpdateIssueParams params) throws BacklogException {
         return factory.createIssue(patch(buildEndpoint("issues/" + params.getIssueIdOrKeyString() + "/import"), params));
     }
 
-    @Override
+    @Override @Deprecated
     public Attachment importDeleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException {
         return factory.createAttachment(delete(buildEndpoint("issues/" + issueIdOrKey + "/attachments/import/" + attachmentId), params));
     }
@@ -594,7 +594,7 @@ public class BacklogClientImpl extends BacklogClientBase implements BacklogClien
         return factory.createWiki(post(buildEndpoint("wikis"), params));
     }
 
-    @Override
+    @Override @Deprecated
     public Wiki importWiki(ImportWikiParams params) {
         return factory.importWiki(post(buildEndpoint("wikis/import"), params));
     }

--- a/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
@@ -433,7 +433,7 @@ public class BacklogClientImpl extends BacklogClientBase implements BacklogClien
     }
 
     @Override
-    public Attachment importDeleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException {
+    public Attachment deleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException {
         return factory.createAttachment(delete(buildEndpoint("issues/" + issueIdOrKey + "/attachments/import/" + attachmentId), params));
     }
 

--- a/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
@@ -433,7 +433,7 @@ public class BacklogClientImpl extends BacklogClientBase implements BacklogClien
     }
 
     @Override
-    public Attachment deleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException {
+    public Attachment importDeleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException {
         return factory.createAttachment(delete(buildEndpoint("issues/" + issueIdOrKey + "/attachments/import/" + attachmentId), params));
     }
 

--- a/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
@@ -433,6 +433,11 @@ public class BacklogClientImpl extends BacklogClientBase implements BacklogClien
     }
 
     @Override
+    public Attachment importDeleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException {
+        return factory.createAttachment(delete(buildEndpoint("issues/" + issueIdOrKey + "/attachments/import/" + attachmentId), params));
+    }
+
+    @Override
     public Issue deleteIssue(Object issueIdOrKey) throws BacklogException {
         return factory.createIssue(delete(buildEndpoint("issues/" + issueIdOrKey)));
     }

--- a/src/main/java/com/nulabinc/backlog4j/api/ImportMethods.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/ImportMethods.java
@@ -20,7 +20,7 @@ public interface ImportMethods {
 
     Issue importUpdateIssue(ImportUpdateIssueParams params) throws BacklogException;
 
-    Attachment importDeleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException;
+    Attachment deleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException;
 
     Wiki importWiki(ImportWikiParams params);
 

--- a/src/main/java/com/nulabinc/backlog4j/api/ImportMethods.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/ImportMethods.java
@@ -16,12 +16,16 @@ import com.nulabinc.backlog4j.api.option.ImportWikiParams;
  */
 public interface ImportMethods {
 
+    @Deprecated
     Issue importIssue(ImportIssueParams params) throws BacklogException;
 
+    @Deprecated
     Issue importUpdateIssue(ImportUpdateIssueParams params) throws BacklogException;
 
+    @Deprecated
     Attachment importDeleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException;
 
+    @Deprecated
     Wiki importWiki(ImportWikiParams params);
 
 }

--- a/src/main/java/com/nulabinc/backlog4j/api/ImportMethods.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/ImportMethods.java
@@ -20,7 +20,7 @@ public interface ImportMethods {
 
     Issue importUpdateIssue(ImportUpdateIssueParams params) throws BacklogException;
 
-    Attachment deleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException;
+    Attachment importDeleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException;
 
     Wiki importWiki(ImportWikiParams params);
 

--- a/src/main/java/com/nulabinc/backlog4j/api/ImportMethods.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/ImportMethods.java
@@ -1,8 +1,10 @@
 package com.nulabinc.backlog4j.api;
 
+import com.nulabinc.backlog4j.Attachment;
 import com.nulabinc.backlog4j.BacklogException;
 import com.nulabinc.backlog4j.Issue;
 import com.nulabinc.backlog4j.Wiki;
+import com.nulabinc.backlog4j.api.option.ImportDeleteAttachmentParams;
 import com.nulabinc.backlog4j.api.option.ImportIssueParams;
 import com.nulabinc.backlog4j.api.option.ImportUpdateIssueParams;
 import com.nulabinc.backlog4j.api.option.ImportWikiParams;
@@ -17,6 +19,8 @@ public interface ImportMethods {
     Issue importIssue(ImportIssueParams params) throws BacklogException;
 
     Issue importUpdateIssue(ImportUpdateIssueParams params) throws BacklogException;
+
+    Attachment importDeleteAttachment(Object issueIdOrKey, Object attachmentId, ImportDeleteAttachmentParams params) throws BacklogException;
 
     Wiki importWiki(ImportWikiParams params);
 

--- a/src/main/java/com/nulabinc/backlog4j/api/option/DeleteParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/DeleteParams.java
@@ -1,0 +1,21 @@
+package com.nulabinc.backlog4j.api.option;
+
+import com.nulabinc.backlog4j.http.NameValuePair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parameters for delete request.
+ *
+ * @author nulab-inc
+ */
+public abstract class DeleteParams {
+
+    protected List<NameValuePair> parameters = new ArrayList<NameValuePair>();
+
+    public List<NameValuePair> getParamList() {
+        return parameters;
+    }
+
+}

--- a/src/main/java/com/nulabinc/backlog4j/api/option/ImportDeleteAttachmentParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/ImportDeleteAttachmentParams.java
@@ -1,0 +1,24 @@
+package com.nulabinc.backlog4j.api.option;
+
+import com.nulabinc.backlog4j.http.NameValuePair;
+
+/**
+ * @author nulab-inc
+ */
+public class ImportDeleteAttachmentParams extends DeleteParams {
+
+    /**
+     * Constructor
+     */
+    public ImportDeleteAttachmentParams() {}
+
+    public ImportDeleteAttachmentParams createdUserId(long createdUserId) {
+        parameters.add(new NameValuePair("createdUserId", String.valueOf(createdUserId)));
+        return this;
+    }
+
+    public ImportDeleteAttachmentParams created(String created) {
+        parameters.add(new NameValuePair("created", created));
+        return this;
+    }
+}

--- a/src/main/java/com/nulabinc/backlog4j/http/BacklogHttpClient.java
+++ b/src/main/java/com/nulabinc/backlog4j/http/BacklogHttpClient.java
@@ -20,6 +20,6 @@ public interface BacklogHttpClient {
     BacklogHttpResponse post(String endpoint, List<NameValuePair> postParams) throws BacklogException;
     BacklogHttpResponse patch(String endpoint, List<NameValuePair> patchParams) throws BacklogException;
     BacklogHttpResponse put(String endpoint, List<NameValuePair> patchParams) throws BacklogException;
-    BacklogHttpResponse delete(String endpoint, NameValuePair param) throws BacklogException;
+    BacklogHttpResponse delete(String endpoint, List<NameValuePair> deleteParams) throws BacklogException;
     BacklogHttpResponse postMultiPart(String endpoint, Map<String, Object> postParams) throws BacklogException;
 }

--- a/src/main/java/com/nulabinc/backlog4j/http/BacklogHttpClientImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/http/BacklogHttpClientImpl.java
@@ -109,15 +109,11 @@ public class BacklogHttpClientImpl implements BacklogHttpClient {
     }
 
     @Override
-    public BacklogHttpResponse delete(String endpoint, NameValuePair param) throws BacklogException {
+    public BacklogHttpResponse delete(String endpoint, List<NameValuePair> params) throws BacklogException {
         String url = getUrl(endpoint);
         HttpURLConnection urlConnection = openUrlConnection(url, "DELETE", CONTENT_TYPE);
         urlConnection.setDoInput(true);
         urlConnection.setDoOutput(true);
-        List<NameValuePair> params = new ArrayList<NameValuePair>();
-        if (param != null) {
-            params.add(param);
-        }
         writeParams(urlConnection, params);
         return new BacklogHttpResponseImpl(urlConnection);
     }

--- a/src/test/java/com/nulabinc/backlog4j/api/option/ImportDeleteAttachmentTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/api/option/ImportDeleteAttachmentTest.java
@@ -1,0 +1,29 @@
+package com.nulabinc.backlog4j.api.option;
+
+import com.nulabinc.backlog4j.http.NameValuePair;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author nulab-inc
+ */
+public class ImportDeleteAttachmentTest extends AbstractParamsTest {
+    @Test
+    public void createParamTest() throws UnsupportedEncodingException {
+
+        // when
+        ImportDeleteAttachmentParams params = new ImportDeleteAttachmentParams();
+        params.created("2018-01-11T10:36:49+0900");
+        params.createdUserId(4000000002l);
+
+        // then
+        List<NameValuePair> parameters = params.getParamList();
+        assertEquals(2, parameters.size());
+        assertEquals(true, existsOneKeyValue(parameters, "createdUserId", "4000000002"));
+        assertEquals(true, existsOneKeyValue(parameters, "created", "2018-01-11T10:36:49+0900"));
+    }
+}


### PR DESCRIPTION
Migration tool requires a delete attachment API for import.
Multiple parameter support for DELETE.