### PR TITLE
Add module system support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,8 @@ javadoc {
 jar {
     manifest {
         attributes('Implementation-Title': archivesBaseName,
-                   'Implementation-Version': archiveVersion)
+                   'Implementation-Version': archiveVersion,
+                   'Automatic-Module-Name': archiveBaseName)
     }
 }
 


### PR DESCRIPTION
Add “Automatic-Module-Name" to MANIFEST.MF to make it compatible with Java Platform Module System.