### PR TITLE
feat: add grandchild issue settings support

### DIFF
--- a/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/BacklogClientImpl.java
@@ -434,6 +434,11 @@ public class BacklogClientImpl extends BacklogClientBase implements BacklogClien
     }
 
     @Override
+    public Issue getIssue(Object issueIdOrKey, GetIssueParams params) throws BacklogException {
+        return factory.createIssue(get(buildEndpoint("issues/" + issueIdOrKey), params));
+    }
+
+    @Override
     public ResponseList<IssueComment> getIssueComments(Object issueIdOrKey) throws BacklogException {
         return factory.createIssueCommentList(get(buildEndpoint("issues/" + issueIdOrKey + "/comments")));
     }

--- a/src/main/java/com/nulabinc/backlog4j/ChildIssueSummary.java
+++ b/src/main/java/com/nulabinc/backlog4j/ChildIssueSummary.java
@@ -1,0 +1,13 @@
+package com.nulabinc.backlog4j;
+
+/**
+ * The interface for Backlog issue's child issue summary data.
+ *
+ * @author nulab-inc
+ */
+public interface ChildIssueSummary {
+
+    long getTotal();
+
+    long getClosed();
+}

--- a/src/main/java/com/nulabinc/backlog4j/Issue.java
+++ b/src/main/java/com/nulabinc/backlog4j/Issue.java
@@ -57,6 +57,29 @@ public interface Issue {
     }
 
 
+    enum Expand {
+        ChildIssueSummary("childIssueSummary");
+
+        Expand(String value) {
+            this.value = value;
+        }
+
+        public String getStrValue() {
+            return value;
+        }
+
+        public static Expand strValueOf(final String anValue) {
+            for (Expand d : values()) {
+                if (d.getStrValue().equals(anValue)) {
+                    return d;
+                }
+            }
+            return null;
+        }
+
+        private String value;
+    }
+
     enum PriorityType {
         High(2), Normal(3), Low(4);
 
@@ -139,4 +162,6 @@ public interface Issue {
     List<SharedFile> getSharedFiles();
 
     List<Star> getStars();
+
+    ChildIssueSummary getChildIssueSummary();
 }

--- a/src/main/java/com/nulabinc/backlog4j/Project.java
+++ b/src/main/java/com/nulabinc/backlog4j/Project.java
@@ -106,6 +106,8 @@ public interface Project {
 
     boolean isSubtaskingEnabled();
 
+    boolean isGrandchildIssueEnabled();
+
     boolean isProjectLeaderCanEditProjectLeader();
 
     TextFormattingRule getTextFormattingRule();

--- a/src/main/java/com/nulabinc/backlog4j/api/IssueMethods.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/IssueMethods.java
@@ -51,6 +51,16 @@ public interface IssueMethods {
     Issue getIssue(Object issueIdOrKey) throws BacklogException;
 
     /**
+     * Returns the issue.
+     *
+     * @param issueIdOrKey the issue identifier
+     * @param params       the issue getting parameters
+     * @return the Issue
+     * @throws BacklogException
+     */
+    Issue getIssue(Object issueIdOrKey, GetIssueParams params) throws BacklogException;
+
+    /**
      * Updates an existing issue.
      *
      * @param params the issue updating parameters

--- a/src/main/java/com/nulabinc/backlog4j/api/option/CreateProjectParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/CreateProjectParams.java
@@ -39,4 +39,9 @@ public class CreateProjectParams extends PostParams {
         parameters.add(new NameValuePair("textFormattingRule", textFormattingRule.getStrValue()));
         parameters.add(new NameValuePair("useDevAttributes", String.valueOf(useDevAttributes)));
     }
+
+    public CreateProjectParams grandchildIssueEnabled(boolean grandchildIssueEnabled) {
+        parameters.add(new NameValuePair("grandchildIssueEnabled", String.valueOf(grandchildIssueEnabled)));
+        return this;
+    }
 }

--- a/src/main/java/com/nulabinc/backlog4j/api/option/GetIssueParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/GetIssueParams.java
@@ -1,0 +1,21 @@
+package com.nulabinc.backlog4j.api.option;
+
+import com.nulabinc.backlog4j.Issue;
+import com.nulabinc.backlog4j.http.NameValuePair;
+
+import java.util.List;
+
+/**
+ * Parameters for get issue API.
+ *
+ * @author nulab-inc
+ */
+public class GetIssueParams extends GetParams {
+
+    public GetIssueParams expand(List<Issue.Expand> expands) {
+        for (Issue.Expand expand : expands) {
+            parameters.add(new NameValuePair("expand[]", expand.getStrValue()));
+        }
+        return this;
+    }
+}

--- a/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesCountParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesCountParams.java
@@ -14,7 +14,9 @@ import java.util.List;
 public class GetIssuesCountParams extends GetParams {
 
     public enum ParentChildType {
-        All(0), NotChild(1), Child(2), NotChildNotParent(3), Parent(4);
+        All(0), NotChild(1), Child(2), NotChildNotParent(3), Parent(4),
+        GrandchildIssue(5), ChildIssue(6), ParentIssue(7),
+        ExcludeGrandchild(8), ExcludeGrandparent(9), LeafIssue(10);
 
         ParentChildType(int intValue) {
             this.intValue = intValue;

--- a/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesParams.java
@@ -60,7 +60,9 @@ public class GetIssuesParams extends GetParams {
     }
 
     public enum ParentChildType {
-        All(0), NotChild(1), Child(2), NotChildNotParent(3), Parent(4);
+        All(0), NotChild(1), Child(2), NotChildNotParent(3), Parent(4),
+        GrandchildIssue(5), ChildIssue(6), ParentIssue(7),
+        ExcludeGrandchild(8), ExcludeGrandparent(9), LeafIssue(10);
 
         ParentChildType(int intValue) {
             this.intValue = intValue;
@@ -151,6 +153,13 @@ public class GetIssuesParams extends GetParams {
 
     public GetIssuesParams parentChildType(ParentChildType parentChildType) {
         parameters.add(new NameValuePair("parentChild", String.valueOf(parentChildType.getIntValue())));
+        return this;
+    }
+
+    public GetIssuesParams expand(List<Issue.Expand> expands) {
+        for (Issue.Expand expand : expands) {
+            parameters.add(new NameValuePair("expand[]", expand.getStrValue()));
+        }
         return this;
     }
 

--- a/src/main/java/com/nulabinc/backlog4j/api/option/UpdateProjectParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/UpdateProjectParams.java
@@ -44,6 +44,11 @@ public class UpdateProjectParams extends PatchParams {
         return this;
     }
 
+    public UpdateProjectParams grandchildIssueEnabled(boolean grandchildIssueEnabled) {
+        parameters.add(new NameValuePair("grandchildIssueEnabled", String.valueOf(grandchildIssueEnabled)));
+        return this;
+    }
+
     public UpdateProjectParams projectLeaderCanEditProjectLeader(boolean projectLeaderCanEditProjectLeader) {
         parameters.add(new NameValuePair("projectLeaderCanEditProjectLeader", String.valueOf(projectLeaderCanEditProjectLeader)));
         return this;

--- a/src/main/java/com/nulabinc/backlog4j/internal/json/ChildIssueSummaryJSONImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/internal/json/ChildIssueSummaryJSONImpl.java
@@ -1,0 +1,61 @@
+package com.nulabinc.backlog4j.internal.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.nulabinc.backlog4j.ChildIssueSummary;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * @author nulab-inc
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChildIssueSummaryJSONImpl implements ChildIssueSummary {
+
+    private long total;
+    private long closed;
+
+    @Override
+    public long getTotal() {
+        return total;
+    }
+
+    @Override
+    public long getClosed() {
+        return closed;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        ChildIssueSummaryJSONImpl rhs = (ChildIssueSummaryJSONImpl) obj;
+        return new EqualsBuilder()
+                .append(this.total, rhs.total)
+                .append(this.closed, rhs.closed)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(total)
+                .append(closed)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("total", total)
+                .append("closed", closed)
+                .toString();
+    }
+}

--- a/src/main/java/com/nulabinc/backlog4j/internal/json/IssueJSONImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/internal/json/IssueJSONImpl.java
@@ -64,6 +64,8 @@ public class IssueJSONImpl implements Issue {
     private SharedFile[] sharedFiles;
     @JsonDeserialize(as = StarJSONImpl[].class)
     private Star[] stars;
+    @JsonDeserialize(as = ChildIssueSummaryJSONImpl.class)
+    private ChildIssueSummary childIssueSummary;
 
     @Override
     public long getId() {
@@ -238,6 +240,11 @@ public class IssueJSONImpl implements Issue {
     }
 
     @Override
+    public ChildIssueSummary getChildIssueSummary() {
+        return childIssueSummary;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == null) {
             return false;
@@ -277,6 +284,7 @@ public class IssueJSONImpl implements Issue {
                 .append(this.attachments, rhs.attachments)
                 .append(this.sharedFiles, rhs.sharedFiles)
                 .append(this.stars, rhs.stars)
+                .append(this.childIssueSummary, rhs.childIssueSummary)
                 .isEquals();
     }
 
@@ -310,6 +318,7 @@ public class IssueJSONImpl implements Issue {
                 .append(attachments)
                 .append(sharedFiles)
                 .append(stars)
+                .append(childIssueSummary)
                 .toHashCode();
     }
 
@@ -343,6 +352,7 @@ public class IssueJSONImpl implements Issue {
                 .append("attachments", attachments)
                 .append("sharedFiles", sharedFiles)
                 .append("stars", stars)
+                .append("childIssueSummary", childIssueSummary)
                 .toString();
     }
 }

--- a/src/main/java/com/nulabinc/backlog4j/internal/json/ProjectJSONImpl.java
+++ b/src/main/java/com/nulabinc/backlog4j/internal/json/ProjectJSONImpl.java
@@ -17,6 +17,7 @@ public class ProjectJSONImpl implements Project {
     private String name;
     private boolean chartEnabled;
     private boolean subtaskingEnabled;
+    private boolean grandchildIssueEnabled;
     private boolean projectLeaderCanEditProjectLeader;
     private String textFormattingRule;
     private boolean archived;
@@ -56,6 +57,11 @@ public class ProjectJSONImpl implements Project {
     @Override
     public boolean isSubtaskingEnabled() {
         return subtaskingEnabled;
+    }
+
+    @Override
+    public boolean isGrandchildIssueEnabled() {
+        return grandchildIssueEnabled;
     }
 
     @Override
@@ -129,6 +135,7 @@ public class ProjectJSONImpl implements Project {
                 .append(this.name, rhs.name)
                 .append(this.chartEnabled, rhs.chartEnabled)
                 .append(this.subtaskingEnabled, rhs.subtaskingEnabled)
+                .append(this.grandchildIssueEnabled, rhs.grandchildIssueEnabled)
                 .append(this.textFormattingRule, rhs.textFormattingRule)
                 .append(this.archived, rhs.archived)
                 .append(this.useFileSharing, rhs.useFileSharing)
@@ -152,6 +159,7 @@ public class ProjectJSONImpl implements Project {
                 .append(name)
                 .append(chartEnabled)
                 .append(subtaskingEnabled)
+                .append(grandchildIssueEnabled)
                 .append(textFormattingRule)
                 .append(archived)
                 .append(useFileSharing)
@@ -175,6 +183,7 @@ public class ProjectJSONImpl implements Project {
                 .append("name", name)
                 .append("chartEnabled", chartEnabled)
                 .append("subtaskingEnabled", subtaskingEnabled)
+                .append("grandchildIssueEnabled", grandchildIssueEnabled)
                 .append("textFormattingRule", textFormattingRule)
                 .append("archived", archived)
                 .append("useFileSharing", useFileSharing)

--- a/src/test/java/com/nulabinc/backlog4j/BacklogClientImplTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/BacklogClientImplTest.java
@@ -159,6 +159,11 @@ public class BacklogClientImplTest {
         }
 
         @Override
+        public boolean isGrandchildIssueEnabled() {
+            return false;
+        }
+
+        @Override
         public boolean isProjectLeaderCanEditProjectLeader() {
             return false;
         }

--- a/src/test/java/com/nulabinc/backlog4j/api/option/CreateProjectParamsTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/api/option/CreateProjectParamsTest.java
@@ -1,0 +1,33 @@
+package com.nulabinc.backlog4j.api.option;
+
+import com.nulabinc.backlog4j.Project;
+import com.nulabinc.backlog4j.http.NameValuePair;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author nulab-inc
+ */
+public class CreateProjectParamsTest extends AbstractParamsTest {
+    @Test
+    public void createParamWithGrandchildIssueEnabledTest() {
+
+        // when
+        CreateProjectParams params = new CreateProjectParams(
+                "test", "TEST",
+                false, false, true, false,
+                true, true, true, false, true, false,
+                Project.TextFormattingRule.Markdown, false);
+        params.grandchildIssueEnabled(true);
+
+        // then
+        List<NameValuePair> parameters = params.getParamList();
+        assertTrue(existsOneKeyValue(parameters, "name", "test"));
+        assertTrue(existsOneKeyValue(parameters, "key", "TEST"));
+        assertTrue(existsOneKeyValue(parameters, "subtaskingEnabled", "true"));
+        assertTrue(existsOneKeyValue(parameters, "grandchildIssueEnabled", "true"));
+    }
+}

--- a/src/test/java/com/nulabinc/backlog4j/api/option/GetIssueParamsTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/api/option/GetIssueParamsTest.java
@@ -1,0 +1,29 @@
+package com.nulabinc.backlog4j.api.option;
+
+import com.nulabinc.backlog4j.Issue;
+import com.nulabinc.backlog4j.http.NameValuePair;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author nulab-inc
+ */
+public class GetIssueParamsTest extends AbstractParamsTest {
+    @Test
+    public void createParamTest() {
+
+        // when
+        GetIssueParams params = new GetIssueParams();
+        params.expand(Arrays.asList(Issue.Expand.ChildIssueSummary));
+
+        // then
+        List<NameValuePair> parameters = params.getParamList();
+        assertEquals(1, parameters.size());
+        assertTrue(existsOneKeyValue(parameters, "expand[]", "childIssueSummary"));
+    }
+}

--- a/src/test/java/com/nulabinc/backlog4j/api/option/GetIssuesParamsTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/api/option/GetIssuesParamsTest.java
@@ -102,6 +102,22 @@ public class GetIssuesParamsTest extends AbstractParamsTest {
     }
 
     @Test
+    public void createParamWithExpandAndGrandchildTest() {
+
+        // when
+        GetIssuesParams params = new GetIssuesParams(Arrays.asList(1000000001L));
+        params.parentChildType(GetIssuesParams.ParentChildType.GrandchildIssue)
+                .expand(Arrays.asList(Issue.Expand.ChildIssueSummary));
+
+        // then
+        List<NameValuePair> parameters = params.getParamList();
+        assertEquals(3, parameters.size());
+        assertTrue(existsOneKeyValue(parameters, "projectId[]", "1000000001"));
+        assertTrue(existsOneKeyValue(parameters, "parentChild", "5"));
+        assertTrue(existsOneKeyValue(parameters, "expand[]", "childIssueSummary"));
+    }
+
+    @Test
     public void createParamWithCustomStatusTest() {
 
         // when

--- a/src/test/java/com/nulabinc/backlog4j/api/option/UpdateProjectParamsTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/api/option/UpdateProjectParamsTest.java
@@ -1,0 +1,28 @@
+package com.nulabinc.backlog4j.api.option;
+
+import com.nulabinc.backlog4j.http.NameValuePair;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author nulab-inc
+ */
+public class UpdateProjectParamsTest extends AbstractParamsTest {
+    @Test
+    public void updateParamWithGrandchildIssueEnabledTest() {
+
+        // when
+        UpdateProjectParams params = new UpdateProjectParams("TEST");
+        params.grandchildIssueEnabled(true);
+
+        // then
+        assertEquals("TEST", params.getProjectIdOrKeyString());
+        List<NameValuePair> parameters = params.getParamList();
+        assertEquals(1, parameters.size());
+        assertTrue(existsOneKeyValue(parameters, "grandchildIssueEnabled", "true"));
+    }
+}

--- a/src/test/java/com/nulabinc/backlog4j/internal/json/IssueJSONImplTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/internal/json/IssueJSONImplTest.java
@@ -36,6 +36,8 @@ public class IssueJSONImplTest extends AbstractJSONImplTest {
 
         assertEquals(1079313630, issue.getId());
         assertEquals(1073836557, issue.getProjectId());
+        assertEquals(3, issue.getChildIssueSummary().getTotal());
+        assertEquals(1, issue.getChildIssueSummary().getClosed());
     }
 
     @Test

--- a/src/test/java/com/nulabinc/backlog4j/internal/json/ProjectJSONImplTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/internal/json/ProjectJSONImplTest.java
@@ -64,6 +64,7 @@ public class ProjectJSONImplTest extends AbstractJSONImplTest {
         assertEquals("テストプロジェクト", project.getName());
         assertFalse(project.isChartEnabled());
         assertTrue(project.isSubtaskingEnabled());
+        assertTrue(project.isGrandchildIssueEnabled());
         assertEquals(Project.TextFormattingRule.Backlog, project.getTextFormattingRule());
         assertFalse(project.isArchived());
         assertTrue(project.getUseWiki());

--- a/src/test/resources/json/issue.json
+++ b/src/test/resources/json/issue.json
@@ -49,6 +49,10 @@
     "customFields": [],
     "attachments": [],
     "sharedFiles": [],
-    "stars": []
+    "stars": [],
+    "childIssueSummary": {
+        "total": 3,
+        "closed": 1
+    }
 }
 

--- a/src/test/resources/json/project.json
+++ b/src/test/resources/json/project.json
@@ -6,6 +6,7 @@
     "useBurndown": true,
     "chartEnabled": false,
     "subtaskingEnabled": true,
+    "grandchildIssueEnabled": true,
     "projectLeaderCanEditProjectLeader": false,
     "textFormattingRule": "backlog",
     "archived": false,


### PR DESCRIPTION
## 概要

TypeScript版の [nulab/backlog-js#158](https://github.com/nulab/backlog-js/pull/158) と同等の**孫課題 (grandchild issue)** 対応を backlog4j に追加します。

## 変更内容

### エンティティ
- `Project` に `isGrandchildIssueEnabled()` を追加
- `Issue` に `getChildIssueSummary()` を追加（新規 `ChildIssueSummary` interface / `ChildIssueSummaryJSONImpl`、`getTotal()` / `getClosed()`）
- `Issue.Expand` enum（`ChildIssueSummary("childIssueSummary")`）を追加

### パラメータ (Option)
- `GetIssuesParams` / `GetIssuesCountParams` の `ParentChildType` enum に新値を追加: `GrandchildIssue(5)`, `ChildIssue(6)`, `ParentIssue(7)`, `ExcludeGrandchild(8)`, `ExcludeGrandparent(9)`, `LeafIssue(10)`
- `GetIssuesParams` に `expand(List<Issue.Expand>)`（`expand[]=childIssueSummary`）を追加
- 新規 `GetIssueParams`（`expand` 対応）を追加
- `CreateProjectParams` / `UpdateProjectParams` に fluent な `grandchildIssueEnabled(boolean)` を追加（既存コンストラクタは非破壊）

### API メソッド
- `getIssue(Object issueIdOrKey, GetIssueParams params)` オーバーロードを追加

## テスト
- Project / Issue の JSON fixture・テストに新フィールド検証を追加
- `expand` と孫課題 `ParentChildType` の検証テスト、`GetIssueParamsTest` を追加

## 備考
TypeScript版にあった License の `grandchildIssueEnabled` は、backlog4j に License エンティティ / `getLicence` API 自体が存在しないため対象外としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)