### PR TITLE
fix(ci): grant contents:write to build job for JReleaser release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## 概要

master への push で走る `Build and Release` ワークフロー（`build.yml`）の JReleaser `full-release` ステップが **403 Forbidden** で失敗している問題を修正します。

参考: 失敗した CI 実行 https://github.com/nulab/backlog4j/actions/runs/28573715743

## 原因

```
[INFO]  Releasing to https://github.com/nulab/backlog4j@master
[DEBUG] deleting release early-access from nulab/backlog4j
jreleaser.shadow.org.jreleaser.sdk.commons.RestAPIException: 403: Forbidden
{"message":"Resource not accessible by integration", ... "status":"403"}
```

- ビルド・テスト・Maven Central (snapshot) デプロイはすべて成功しており、失敗しているのは GitHub リリース（`early-access`）の削除・再作成部分のみ。
- ワークフロー YAML 自体は 2025-07-09 以降変更されておらず、前回の master push（2025-07-14）は成功していた。
- 変わったのはリポジトリ側の設定で、`default_workflow_permissions` が現在 `read`（読み取り専用）になっている。以前は write だったため YAML に `permissions:` を書かなくても `GITHUB_TOKEN` でリリースを操作できていた。
- 今回のマージがデフォルト権限変更後の最初の master push だったため顕在化した（コード変更とは無関係）。

## 修正内容

`build` ジョブに `permissions: contents: write` を明示的に付与し、リポジトリ/組織のデフォルト権限に依存せずリリース操作が行えるようにする。

```yaml
jobs:
  build:
    runs-on: ubuntu-latest

    permissions:
      contents: write
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)