### PR TITLE
Clarify ParentChildType naming for grandchild issue values

### DIFF
--- a/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesCountParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesCountParams.java
@@ -19,7 +19,10 @@ public class GetIssuesCountParams extends GetParams {
         @Deprecated
         Child(2),
         ChildOrGrandchild(2),
+        /** @deprecated Use {@link #Standalone}. */
+        @Deprecated
         NotChildNotParent(3),
+        Standalone(3),
         /** @deprecated Use {@link #HasChildren}. */
         @Deprecated
         Parent(4),

--- a/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesCountParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesCountParams.java
@@ -14,9 +14,18 @@ import java.util.List;
 public class GetIssuesCountParams extends GetParams {
 
     public enum ParentChildType {
-        All(0), NotChild(1), Child(2), NotChildNotParent(3), Parent(4),
-        GrandchildIssue(5), ChildIssue(6), ParentIssue(7),
-        ExcludeGrandchild(8), ExcludeGrandparent(9), LeafIssue(10);
+        All(0), NotChild(1),
+        /** @deprecated Use {@link #ChildOrGrandchild}. */
+        @Deprecated
+        Child(2),
+        ChildOrGrandchild(2),
+        NotChildNotParent(3),
+        /** @deprecated Use {@link #HasChildren}. */
+        @Deprecated
+        Parent(4),
+        HasChildren(4),
+        GrandchildOnly(5), ChildOnly(6), TopLevelOnly(7),
+        ExcludeGrandchild(8), ExcludeTopLevel(9), LeafOnly(10);
 
         ParentChildType(int intValue) {
             this.intValue = intValue;

--- a/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesParams.java
@@ -65,7 +65,10 @@ public class GetIssuesParams extends GetParams {
         @Deprecated
         Child(2),
         ChildOrGrandchild(2),
+        /** @deprecated Use {@link #Standalone}. */
+        @Deprecated
         NotChildNotParent(3),
+        Standalone(3),
         /** @deprecated Use {@link #HasChildren}. */
         @Deprecated
         Parent(4),

--- a/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesParams.java
+++ b/src/main/java/com/nulabinc/backlog4j/api/option/GetIssuesParams.java
@@ -60,9 +60,18 @@ public class GetIssuesParams extends GetParams {
     }
 
     public enum ParentChildType {
-        All(0), NotChild(1), Child(2), NotChildNotParent(3), Parent(4),
-        GrandchildIssue(5), ChildIssue(6), ParentIssue(7),
-        ExcludeGrandchild(8), ExcludeGrandparent(9), LeafIssue(10);
+        All(0), NotChild(1),
+        /** @deprecated Use {@link #ChildOrGrandchild}. */
+        @Deprecated
+        Child(2),
+        ChildOrGrandchild(2),
+        NotChildNotParent(3),
+        /** @deprecated Use {@link #HasChildren}. */
+        @Deprecated
+        Parent(4),
+        HasChildren(4),
+        GrandchildOnly(5), ChildOnly(6), TopLevelOnly(7),
+        ExcludeGrandchild(8), ExcludeTopLevel(9), LeafOnly(10);
 
         ParentChildType(int intValue) {
             this.intValue = intValue;

--- a/src/test/java/com/nulabinc/backlog4j/api/option/GetIssuesParamsTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/api/option/GetIssuesParamsTest.java
@@ -34,7 +34,7 @@ public class GetIssuesParamsTest extends AbstractParamsTest {
                 .milestoneIds(Arrays.asList(7000000001L, 7000000002L))
                 .offset(100)
                 .order(GetIssuesParams.Order.Desc)
-                .parentChildType(GetIssuesParams.ParentChildType.NotChildNotParent)
+                .parentChildType(GetIssuesParams.ParentChildType.Standalone)
                 .parentIssueIds(Arrays.asList(8000000001L, 8000000002L))
                 .priorities(Arrays.asList(Issue.PriorityType.High, Issue.PriorityType.Low))
                 .resolutions(Arrays.asList(Issue.ResolutionType.Fixed, Issue.ResolutionType.Invalid))
@@ -126,6 +126,9 @@ public class GetIssuesParamsTest extends AbstractParamsTest {
         assertEquals(4, GetIssuesParams.ParentChildType.HasChildren.getIntValue());
         assertEquals(GetIssuesParams.ParentChildType.Parent.getIntValue(),
                 GetIssuesParams.ParentChildType.HasChildren.getIntValue());
+        assertEquals(3, GetIssuesParams.ParentChildType.Standalone.getIntValue());
+        assertEquals(GetIssuesParams.ParentChildType.NotChildNotParent.getIntValue(),
+                GetIssuesParams.ParentChildType.Standalone.getIntValue());
     }
 
     @Test

--- a/src/test/java/com/nulabinc/backlog4j/api/option/GetIssuesParamsTest.java
+++ b/src/test/java/com/nulabinc/backlog4j/api/option/GetIssuesParamsTest.java
@@ -106,7 +106,7 @@ public class GetIssuesParamsTest extends AbstractParamsTest {
 
         // when
         GetIssuesParams params = new GetIssuesParams(Arrays.asList(1000000001L));
-        params.parentChildType(GetIssuesParams.ParentChildType.GrandchildIssue)
+        params.parentChildType(GetIssuesParams.ParentChildType.GrandchildOnly)
                 .expand(Arrays.asList(Issue.Expand.ChildIssueSummary));
 
         // then
@@ -115,6 +115,17 @@ public class GetIssuesParamsTest extends AbstractParamsTest {
         assertTrue(existsOneKeyValue(parameters, "projectId[]", "1000000001"));
         assertTrue(existsOneKeyValue(parameters, "parentChild", "5"));
         assertTrue(existsOneKeyValue(parameters, "expand[]", "childIssueSummary"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void parentChildTypeAliasesTest() {
+        assertEquals(2, GetIssuesParams.ParentChildType.ChildOrGrandchild.getIntValue());
+        assertEquals(GetIssuesParams.ParentChildType.Child.getIntValue(),
+                GetIssuesParams.ParentChildType.ChildOrGrandchild.getIntValue());
+        assertEquals(4, GetIssuesParams.ParentChildType.HasChildren.getIntValue());
+        assertEquals(GetIssuesParams.ParentChildType.Parent.getIntValue(),
+                GetIssuesParams.ParentChildType.HasChildren.getIntValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Mirrors nulab/backlog-js#172 for the Java client. The `parentChild` search values are now finalized in the public API documentation ([get-issue-list](https://developer.nulab.com/docs/backlog/api/2/get-issue-list/) and the [API parameter update blog](https://backlog.com/ja/blog/backlog-update-api-parameter/)), so this reduces the naming cognitive load flagged in the grandchild support review (#100).

## Changes

Applied to **both** `GetIssuesParams.ParentChildType` and `GetIssuesCountParams.ParentChildType`:

- **Deprecate the misleading published names and add clearer aliases** (additive, non-breaking):
  - `Child` (2) → `@Deprecated`, alias `ChildOrGrandchild` (2)
  - `Parent` (4) → `@Deprecated`, alias `HasChildren` (4)
- **Rename the not-yet-released grandchild values (5–10)** to clearer names:
  | value | before (#100) | after |
  |------:|---------------|-------|
  | 5 | `GrandchildIssue` | `GrandchildOnly` |
  | 6 | `ChildIssue` | `ChildOnly` |
  | 7 | `ParentIssue` | `TopLevelOnly` |
  | 8 | `ExcludeGrandchild` | `ExcludeGrandchild` (unchanged) |
  | 9 | `ExcludeGrandparent` | `ExcludeTopLevel` |
  | 10 | `LeafIssue` | `LeafOnly` |

## Compatibility

- Long-published names `All`/`NotChild`/`Child`/`NotChildNotParent`/`Parent` all keep working; `Child`/`Parent` are only marked `@Deprecated`.
- Values 5–10 were introduced in #100 and have **not** been released in any tag yet, so renaming them is safe. (Confirmed: the grandchild commit is on `master` but not contained in any release tag.)
- No int→enum reverse lookup exists in the codebase, so the two intentional duplicate int values (aliases) cause no ambiguity.

## Verification

- `./gradlew test` (GetIssuesParamsTest / GetIssuesCountParamsTest) ✅ — full project compiles, incl. a new alias test asserting `ChildOrGrandchild==2` and `HasChildren==4`.

## Related

- backlog-js issue: nulab/backlog-js#165
- backlog-js PR: nulab/backlog-js#172