### PR TITLE
chore(release): 2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Backlog4j is a Backlog binding library for Java.
 
 
 ## Updates
+* 2026/07/22 2.8.0 released
 * 2025/07/14 2.7.0 released
 * 2023/11/20 2.6.0 released
 * 2023/07/27 2.5.3 released
@@ -30,14 +31,14 @@ https://github.com/nulab/backlog4j/releases
 
 ### gradle
 
-    'com.nulab-inc:backlog4j:2.7.0'
+    'com.nulab-inc:backlog4j:2.8.0'
 
 ### maven
 
     <dependency>
       <groupId>com.nulab-inc</groupId>
       <artifactId>backlog4j</artifactId>
-      <version>2.7.0</version>
+      <version>2.8.0</version>
     </dependency>
 
 ## How to use
@@ -85,14 +86,14 @@ Backlog4j は Backlog API (https://developer.nulab.com/ja/docs/backlog/#) に簡
 
 ### gradle を利用する場合
 
-    'com.nulab-inc:backlog4j:2.7.0'
+    'com.nulab-inc:backlog4j:2.8.0'
 
 ### maven を利用する場合
 
     <dependency>
       <groupId>com.nulab-inc</groupId>
       <artifactId>backlog4j</artifactId>
-      <version>2.7.0</version>
+      <version>2.8.0</version>
     </dependency>
 
 ## 使い方

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.7.1-SNAPSHOT
+version=2.8.0


### PR DESCRIPTION
## 概要
リリース version 2.8.0 のためのバージョン更新です。

## ⚠️ このPRをmasterにマージするとリリースされます
`.github/workflows/build.yml`（"Build and Release"）が **master への push で自動発火**し、JReleaser `full-release` により Maven Central への公開・GitHub Release/タグ作成が行われます。手動での Actions 実行は不要です。CI グリーン確認・レビュー完了後、リリースするタイミングでマージしてください。

## 変更内容
- `gradle.properties`: `2.7.1-SNAPSHOT` → `2.8.0`
- `README.md`: インストール例のバージョン更新（gradle / maven, EN / JP）、Updates にリリース履歴追加

## バージョン方針
2.7.0 以降、以下の新しい public API が追加されているため、SemVer に従い **minor bump（2.8.0）** としています。
- #100 孫課題サポート（`grandchildIssueEnabled`, `childIssueSummary`, `Expand` enum, `ParentChildType` の孫課題用値, `expand` パラメータ）
- #102 `ParentChildType` の命名整理（新エイリアス追加・旧名 deprecated）

## リリースの流れ
1. CI がグリーンであることを確認・レビュー
2. **master にマージ → `build.yml` が自動でリリース実行**（Maven Central 公開 + GitHub Release）
3. リリース後、`gradle.properties` を次の開発版（`2.8.1-SNAPSHOT`）へ戻すPRを別途

Refs: PASTA-1863

🤖 Generated with [Claude Code](https://claude.com/claude-code)